### PR TITLE
Quiet task only runs on :solid_queue_role

### DIFF
--- a/lib/capistrano/tasks/solid_queue.rake
+++ b/lib/capistrano/tasks/solid_queue.rake
@@ -60,7 +60,7 @@ namespace :solid_queue do # rubocop:disable Metrics
 
   desc "Quiet solid_queue (start graceful termination)"
   task :quiet do
-    on roles(:app) do
+    on roles(fetch(:solid_queue_role)) do
       plugin.execute_systemd("kill", "-s", "SIGTERM", fetch(:solid_queue_service_unit_name), raise_on_non_zero_exit: false)
     end
   end


### PR DESCRIPTION
Instead of running the quiet task on all roles, limit it only to the :solid_queue_role (:db by default).

Resolves #4 